### PR TITLE
Create fallback for Array.isArray if used as a browser package

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,17 +20,20 @@ module.exports = function kindOf(val) {
   if (typeof val !== 'object') {
     return typeof val;
   }
-  if (Array.isArray(val)) {
+  if (Array.isArray && Array.isArray(val)) {
     return 'array';
   }
-
+  
   var type = toString.call(val);
-
+  
   if (val instanceof RegExp || type === '[object RegExp]') {
     return 'regexp';
   }
   if (val instanceof Date || type === '[object Date]') {
     return 'date';
+  }
+  if(type === '[object Array]') {
+    return 'array';
   }
   if (type === '[object Function]') {
     return 'function';


### PR DESCRIPTION
I'd like to use this module to optionally replace some Lodash type functions in an [Optimizely opensource Flux library](https://github.com/optimizely/nuclear-js/blob/master/src/utils.js).  Seems like there should be a fallback for `Array.isArray`. You probably have a "slicker" way to do this, but if you're open to it, would be great to use this module.