### PR TITLE
Adding ArrayBuffer, DataView, adding slight Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ kindOf(new Float32Array());
 
 kindOf(new Float64Array());
 //=> 'float64array'
+
+kindOf(new ArrayBuffer());
+//=> 'arraybuffer'
+
+kindOf(new DataView(new ArrayBuffer()));
+//=> 'dataview'
 ```
 
 ## Benchmarks

--- a/browser.js
+++ b/browser.js
@@ -2,6 +2,35 @@
 var isBuffer = require('is-buffer');
 var toString = Object.prototype.toString;
 
+// Prototype-less object (so lookups don't need to go up the prototype chain)
+var typeMap = Object.create(null);
+typeMap['[object RegExp]'] =  'regexp';
+typeMap['[object Date]'] =  'date';
+typeMap['[object Arguments]'] =  'arguments';
+
+// es6 =  Map; WeakMap; Set; WeakSet
+typeMap['[object Set]'] =  'set';
+typeMap['[object WeakSet]'] =  'weakset';
+typeMap['[object Map]'] =  'map';
+typeMap['[object WeakMap]'] =  'weakmap';
+typeMap['[object Symbol]'] =  'symbol';
+
+// typed arrays
+typeMap['[object Int8Array]'] =  'int8array';
+typeMap['[object Uint8Array]'] =  'uint8array';
+typeMap['[object Uint8ClampedArray]'] =  'uint8clampedarray';
+typeMap['[object Int16Array]'] =  'int16array';
+typeMap['[object Uint16Array]'] =  'uint16array';
+typeMap['[object Int32Array]'] =  'int32array';
+typeMap['[object Uint32Array]'] =  'uint32array';
+typeMap['[object Float32Array]'] =  'float32array';
+typeMap['[object Float64Array]'] =  'float64array';
+
+// structured data
+typeMap['[object ArrayBuffer]'] =  'arraybuffer';
+typeMap['[object DataView]'] =  'dataview';
+
+
 /**
  * Get the native `typeof` a value.
  *
@@ -45,68 +74,16 @@ module.exports = function kindOf(val) {
     return 'date';
   }
 
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-
   // buffer
   if (typeof Buffer !== 'undefined' && isBuffer(val)) {
     return 'buffer';
   }
 
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
+  // other objects
+  var type = toString.call(val);
 
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
+  if (typeMap[type]) {
+    return typeMap[type];
   }
 
   // must be a plain object

--- a/index.js
+++ b/index.js
@@ -1,6 +1,35 @@
 var isBuffer = require('is-buffer');
 var toString = Object.prototype.toString;
 
+// Prototype-less object (so lookups don't need to go up the prototype chain)
+var typeMap = Object.create(null);
+typeMap['[object RegExp]'] =  'regexp';
+typeMap['[object Date]'] =  'date';
+typeMap['[object Arguments]'] =  'arguments';
+
+// es6 =  Map; WeakMap; Set; WeakSet
+typeMap['[object Set]'] =  'set';
+typeMap['[object WeakSet]'] =  'weakset';
+typeMap['[object Map]'] =  'map';
+typeMap['[object WeakMap]'] =  'weakmap';
+typeMap['[object Symbol]'] =  'symbol';
+
+// typed arrays
+typeMap['[object Int8Array]'] =  'int8array';
+typeMap['[object Uint8Array]'] =  'uint8array';
+typeMap['[object Uint8ClampedArray]'] =  'uint8clampedarray';
+typeMap['[object Int16Array]'] =  'int16array';
+typeMap['[object Uint16Array]'] =  'uint16array';
+typeMap['[object Int32Array]'] =  'int32array';
+typeMap['[object Uint32Array]'] =  'uint32array';
+typeMap['[object Float32Array]'] =  'float32array';
+typeMap['[object Float64Array]'] =  'float64array';
+
+// structured data
+typeMap['[object ArrayBuffer]'] =  'arraybuffer';
+typeMap['[object DataView]'] =  'dataview';
+
+
 /**
  * Get the native `typeof` a value.
  *
@@ -44,68 +73,16 @@ module.exports = function kindOf(val) {
     return 'date';
   }
 
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-
   // buffer
   if (typeof Buffer !== 'undefined' && isBuffer(val)) {
     return 'buffer';
   }
 
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
+  // other objects
+  var type = toString.call(val);
 
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
+  if (typeMap[type]) {
+    return typeMap[type];
   }
 
   // must be a plain object

--- a/test.js
+++ b/test.js
@@ -180,6 +180,15 @@ describe('kindOf', function() {
         var float64array = new Float64Array();
         kindOf(float64array).should.equal('float64array');
       });
+      it('should work for ArrayBuffer', function() {
+        var arrayBuffer = new ArrayBuffer();
+        kindOf(arrayBuffer).should.equal('arraybuffer');
+      });
+      it('should work for DataView', function() {
+        var arrayBuffer = new ArrayBuffer();
+        var dataView = new DataView(arrayBuffer);
+        kindOf(dataView).should.equal('dataview');
+      });
     });
   }
 });


### PR DESCRIPTION
Adding `ArrayBuffer` and `DataView` to the `kindOf` check.

Also, rather than if-checking each of the types, I've thrown them
into a map. `1 if-check` probably faster than `19 if-checks` (not by much, but it looks cleaner :).

``` javascript
if (type ==='A') {
    return 'a';
}
if (type === 'B') {
    return 'b';
}
```

Turns into:

``` javascript
var typeMap = {
    A: 'a',
    B: 'b'
};
if (typeMap[type]) {
    return typeMap[type];
}
```

The order of checks has been mostly been maintained, but I did put the
`Buffer` check above the `RegExp`, `Date`, and `Arguments` to simplify stuff.

If the order is a problem let me know and I can split the typeMap
into two parts (before the Buffer check and after).
