### PR TITLE
Added undefined check

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -30,7 +30,7 @@ module.exports = function kindOf(val) {
 
   // functions
   if (type === 'function' || val instanceof Function) {
-    if (val.constructor.name.slice(0, 9) === 'Generator') {
+    if (typeof val.constructor.name !== 'undefined' && val.constructor.name.slice(0, 9) === 'Generator') {
       return 'generatorfunction';
     }
     return 'function';

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function kindOf(val) {
 
   // functions
   if (type === 'function' || val instanceof Function) {
-    if (val.constructor.name.slice(0, 9) === 'Generator') {
+    if (typeof val.constructor.name !== 'undefined' && val.constructor.name.slice(0, 9) === 'Generator') {
       return 'generatorfunction';
     }
     return 'function';


### PR DESCRIPTION
IE11 and below doesn’t support the name property of the constructor
object, so put in a check to avoid exceptions when slice() method is
called.