### PR TITLE
fix type checking vul in ctorName

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function kindOf(val) {
 };
 
 function ctorName(val) {
-  return val.constructor ? val.constructor.name : null;
+  return val.constructor && typeof val.constructor === 'function' ? val.constructor.name : null;
 }
 
 function isArray(val) {


### PR DESCRIPTION
Thanks for the response. Here is the PR that fixes the issue.

Discussion about how this might be used maliciously:
Kind-of is widely used for type checking. If developers use kind-of to check  whether user-input object is in string format, the attacker can cheat kind-of into recognizing an arbitrary plain object into str type. As a result, all the built-in attributes (e.g., length) of str type can be manipulated.  For example, if the manipulated user_obj.length is inserted into the DB, SQL Injection can be introduced.
