### PR TITLE
add support for 'bigint', fix deprecated Buffer constructor call

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -24,11 +24,14 @@ kindOf(true);
 kindOf(false);
 //=> 'boolean'
 
-kindOf(new Buffer(''));
+kindOf(Buffer.from(''));
 //=> 'buffer'
 
 kindOf(42);
 //=> 'number'
+
+kindOf(42n);
+//=> 'bigint'
 
 kindOf('str');
 //=> 'string'

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function kindOf(val) {
   if (type === 'string') return 'string';
   if (type === 'number') return 'number';
   if (type === 'symbol') return 'symbol';
+  if (type === 'bigint') return 'bigint';
   if (type === 'function') {
     return isGeneratorFn(val) ? 'generatorfunction' : 'function';
   }

--- a/test/es6/index.js
+++ b/test/es6/index.js
@@ -135,5 +135,11 @@ module.exports = function() {
       var float64array = new Float64Array();
       assert.equal(kindOf(float64array), 'float64array');
     });
+
+    if ( typeof BigInt === 'function') {
+        it('should work for BigInt', function () {
+            assert.strictEqual(kindOf(42n), 'bigint');
+        });
+    }
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ describe('kindOf', function() {
     });
 
     it('should work for buffers', function() {
-      assert.equal(kindOf(new Buffer('')), 'buffer');
+      assert.equal(kindOf(Buffer.from('')), 'buffer');
     });
 
     it('should work for objects', function() {


### PR DESCRIPTION
- add check for type being 'bigint'
- add test for 'bigint' if `BigInt` constructor exists (Node version 10+, I think)
- change `new Buffer()` to `Buffer.from('')` in `test.js` and `.verb.md` since the constructor call has been deprecated